### PR TITLE
Removed dependence on 3.11

### DIFF
--- a/cfe_internal/enterprise/federation/federation.cf
+++ b/cfe_internal/enterprise/federation/federation.cf
@@ -365,9 +365,12 @@ bundle agent entry
 
 bundle agent setup_status
 {
-@if minimum_version(3.11)
   vars:
     "role" string => "$(cfengine_enterprise_federation:config.role)";
+    "ssh_pub_key"
+      string => readfile( "$(cfengine_enterprise_federation:transport_user.ssh_pub_key)" ),
+      if => fileexists( "$(cfengine_enterprise_federation:transport_user.ssh_pub_key)" );
+
   classes:
     "superhub_setup_status_complete"
       expression => "any",
@@ -384,10 +387,8 @@ bundle agent setup_status
         create => "true",
         template_method => "inline_mustache",
         edit_template_string => "{{%-top-}}$(const.n)",
-        template_data => '{ "configured": true, "role": "$(role)", "transport_ssh_public_key": "$(with)" }',
-        with => readfile( "$(cfengine_enterprise_federation:transport_user.ssh_pub_key)" ),
-        if => fileexists( "$(cfengine_enterprise_federation:transport_user.ssh_pub_key)" );
-@endif
+        template_data => '{ "configured": true, "role": "$(role)", "transport_ssh_public_key": "$(ssh_pub_key)" }',
+        if => isvariable( ssh_pub_key );
 }
 
 body file control


### PR DESCRIPTION
This policy runs on any hub where federated reporting is enabled, since we want
old hubs to be able to participate as feeders, this policy should work on
feeders.